### PR TITLE
Add quick links footer and new pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Contact - 2019 ink</title>
+    <style>
+        @font-face {
+            font-family: 'HelveticaNowBold';
+            src: url('fonts/helvetica-now-bold.woff2') format('woff2');
+            font-display: swap;
+        }
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: #000;
+            color: #fff;
+            font-family: 'HelveticaNowBold', sans-serif;
+            text-align: center;
+        }
+        .back-btn {
+            position: fixed;
+            top: calc(30px + env(safe-area-inset-top));
+            left: 30px;
+            color: #fff;
+            text-decoration: none;
+            padding: 15px 25px;
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            background: rgba(0, 0, 0, 0.85);
+            text-transform: uppercase;
+            font-weight: 600;
+            letter-spacing: 1px;
+            transition: all 0.3s ease;
+            border-radius: 8px;
+            -webkit-tap-highlight-color: transparent;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+        .back-btn:hover {
+            background: rgba(255, 255, 255, 0.95);
+            color: #000;
+            transform: translateY(-2px);
+        }
+        .container {
+            padding: 120px 20px;
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" class="back-btn">Home</a>
+    <div class="container">
+        <h1>Contact</h1>
+        <p>Email us at contact@example.com.</p>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -381,6 +381,29 @@
             margin: 0;
         }
 
+        .quick-links {
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 20px;
+            margin: 80px auto 40px auto;
+            padding: 20px;
+            color: #aaa;
+            font-size: 14px;
+            border-top: 1px solid #111;
+        }
+
+        .quick-links a {
+            color: #aaa;
+            text-decoration: none;
+            text-transform: uppercase;
+            transition: color 0.3s ease;
+        }
+
+        .quick-links a:hover {
+            color: #fff;
+        }
+
         @media (max-width: 768px) {
             .cart-content {
                 width: 95%;
@@ -406,6 +429,11 @@
             .back-btn, .cart-btn {
                 padding: 12px 20px;
                 font-size: 14px;
+            }
+
+            .quick-links {
+                flex-direction: column;
+                gap: 10px;
             }
         }
     </style>
@@ -493,6 +521,15 @@
             </div>
         </a>
     </div>
+
+    <footer class="quick-links">
+        <a href="instagram.html">Instagram</a>
+        <a href="contact.html">Contact</a>
+        <a href="support.html">Support</a>
+        <a href="shipping.html">Shipping</a>
+        <a href="returns.html">Returns</a>
+        <a href="size-guide.html">Size Guide</a>
+    </footer>
 
     <script>
         // Cart functionality - persisted using localStorage

--- a/instagram.html
+++ b/instagram.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Instagram - 2019 ink</title>
+    <style>
+        @font-face {
+            font-family: 'HelveticaNowBold';
+            src: url('fonts/helvetica-now-bold.woff2') format('woff2');
+            font-display: swap;
+        }
+
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: #000;
+            color: #fff;
+            font-family: 'HelveticaNowBold', sans-serif;
+            text-align: center;
+        }
+
+        .back-btn {
+            position: fixed;
+            top: calc(30px + env(safe-area-inset-top));
+            left: 30px;
+            color: #fff;
+            text-decoration: none;
+            padding: 15px 25px;
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            background: rgba(0, 0, 0, 0.85);
+            text-transform: uppercase;
+            font-weight: 600;
+            letter-spacing: 1px;
+            transition: all 0.3s ease;
+            border-radius: 8px;
+            -webkit-tap-highlight-color: transparent;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+
+        .back-btn:hover {
+            background: rgba(255, 255, 255, 0.95);
+            color: #000;
+            transform: translateY(-2px);
+        }
+
+        .container {
+            padding: 120px 20px;
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" class="back-btn">Home</a>
+    <div class="container">
+        <h1>Instagram</h1>
+        <p>Follow us on Instagram for updates.</p>
+    </div>
+</body>
+</html>

--- a/returns.html
+++ b/returns.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Returns - 2019 ink</title>
+    <style>
+        @font-face {
+            font-family: 'HelveticaNowBold';
+            src: url('fonts/helvetica-now-bold.woff2') format('woff2');
+            font-display: swap;
+        }
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: #000;
+            color: #fff;
+            font-family: 'HelveticaNowBold', sans-serif;
+            text-align: center;
+        }
+        .back-btn {
+            position: fixed;
+            top: calc(30px + env(safe-area-inset-top));
+            left: 30px;
+            color: #fff;
+            text-decoration: none;
+            padding: 15px 25px;
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            background: rgba(0, 0, 0, 0.85);
+            text-transform: uppercase;
+            font-weight: 600;
+            letter-spacing: 1px;
+            transition: all 0.3s ease;
+            border-radius: 8px;
+            -webkit-tap-highlight-color: transparent;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+        .back-btn:hover {
+            background: rgba(255, 255, 255, 0.95);
+            color: #000;
+            transform: translateY(-2px);
+        }
+        .container {
+            padding: 120px 20px;
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" class="back-btn">Home</a>
+    <div class="container">
+        <h1>Returns</h1>
+        <p>Information about returns will go here.</p>
+    </div>
+</body>
+</html>

--- a/shipping.html
+++ b/shipping.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Shipping - 2019 ink</title>
+    <style>
+        @font-face {
+            font-family: 'HelveticaNowBold';
+            src: url('fonts/helvetica-now-bold.woff2') format('woff2');
+            font-display: swap;
+        }
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: #000;
+            color: #fff;
+            font-family: 'HelveticaNowBold', sans-serif;
+            text-align: center;
+        }
+        .back-btn {
+            position: fixed;
+            top: calc(30px + env(safe-area-inset-top));
+            left: 30px;
+            color: #fff;
+            text-decoration: none;
+            padding: 15px 25px;
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            background: rgba(0, 0, 0, 0.85);
+            text-transform: uppercase;
+            font-weight: 600;
+            letter-spacing: 1px;
+            transition: all 0.3s ease;
+            border-radius: 8px;
+            -webkit-tap-highlight-color: transparent;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+        .back-btn:hover {
+            background: rgba(255, 255, 255, 0.95);
+            color: #000;
+            transform: translateY(-2px);
+        }
+        .container {
+            padding: 120px 20px;
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" class="back-btn">Home</a>
+    <div class="container">
+        <h1>Shipping</h1>
+        <p>Information about shipping will go here.</p>
+    </div>
+</body>
+</html>

--- a/size-guide.html
+++ b/size-guide.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Size Guide - 2019 ink</title>
+    <style>
+        @font-face {
+            font-family: 'HelveticaNowBold';
+            src: url('fonts/helvetica-now-bold.woff2') format('woff2');
+            font-display: swap;
+        }
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: #000;
+            color: #fff;
+            font-family: 'HelveticaNowBold', sans-serif;
+            text-align: center;
+        }
+        .back-btn {
+            position: fixed;
+            top: calc(30px + env(safe-area-inset-top));
+            left: 30px;
+            color: #fff;
+            text-decoration: none;
+            padding: 15px 25px;
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            background: rgba(0, 0, 0, 0.85);
+            text-transform: uppercase;
+            font-weight: 600;
+            letter-spacing: 1px;
+            transition: all 0.3s ease;
+            border-radius: 8px;
+            -webkit-tap-highlight-color: transparent;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+        .back-btn:hover {
+            background: rgba(255, 255, 255, 0.95);
+            color: #000;
+            transform: translateY(-2px);
+        }
+        .container {
+            padding: 120px 20px;
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" class="back-btn">Home</a>
+    <div class="container">
+        <h1>Size Guide</h1>
+        <p>Size charts and measurements coming soon.</p>
+    </div>
+</body>
+</html>

--- a/support.html
+++ b/support.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Support - 2019 ink</title>
+    <style>
+        @font-face {
+            font-family: 'HelveticaNowBold';
+            src: url('fonts/helvetica-now-bold.woff2') format('woff2');
+            font-display: swap;
+        }
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: #000;
+            color: #fff;
+            font-family: 'HelveticaNowBold', sans-serif;
+            text-align: center;
+        }
+        .back-btn {
+            position: fixed;
+            top: calc(30px + env(safe-area-inset-top));
+            left: 30px;
+            color: #fff;
+            text-decoration: none;
+            padding: 15px 25px;
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            background: rgba(0, 0, 0, 0.85);
+            text-transform: uppercase;
+            font-weight: 600;
+            letter-spacing: 1px;
+            transition: all 0.3s ease;
+            border-radius: 8px;
+            -webkit-tap-highlight-color: transparent;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+        .back-btn:hover {
+            background: rgba(255, 255, 255, 0.95);
+            color: #000;
+            transform: translateY(-2px);
+        }
+        .container {
+            padding: 120px 20px;
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" class="back-btn">Home</a>
+    <div class="container">
+        <h1>Support</h1>
+        <p>For assistance please contact support@example.com.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add footer with "quick links" in the homepage
- style quick links for dark theme and responsiveness
- create placeholder pages for Instagram, Contact, Support, Shipping, Returns, and Size Guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d00d9da008329981ab76f9c4310cb