### PR TITLE
Fix home button stacking on mobile returns page

### DIFF
--- a/returns.html
+++ b/returns.html
@@ -40,6 +40,7 @@
             letter-spacing: 1px;
             transition: all 0.3s ease;
             border-radius: 8px;
+            z-index: 100;
             -webkit-tap-highlight-color: transparent;
             backdrop-filter: blur(10px);
             -webkit-backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- ensure the Home button is visible on mobile returns page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d7d8dfcd48329949d3d4430e1487e