### PR TITLE
Fix home button overlap on returns page

### DIFF
--- a/returns.html
+++ b/returns.html
@@ -52,6 +52,7 @@
         .container {
             max-width: 700px;
             width: 100%;
+            padding: 100px 20px;
         }
 
         h1 {


### PR DESCRIPTION
## Summary
- revert previous z-index change
- add padding around returns page content so the Home button doesn't cover the heading

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d7d8dfcd48329949d3d4430e1487e