### PR TITLE
Fix home button layout on returns page

### DIFF
--- a/returns.html
+++ b/returns.html
@@ -52,6 +52,7 @@
         .container {
             max-width: 700px;
             width: 100%;
+            padding: 120px 20px;
         }
 
         h1 {


### PR DESCRIPTION
## Summary
- bump padding at top of returns page so heading clears the Home button on mobile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d7d8dfcd48329949d3d4430e1487e