### PR TITLE
Fix mobile overlap on returns page

### DIFF
--- a/returns.html
+++ b/returns.html
@@ -71,6 +71,16 @@
                 padding-top: 40px;
             }
         }
+
+        @media screen and (max-width: 600px) {
+            body {
+                align-items: flex-start;
+                padding-top: 40px;
+            }
+            .container {
+                padding-top: 140px;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add mobile-specific spacing tweaks for the returns page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687dc19f8d788329aecadb69174312e7