### PR TITLE
Fix logo overlapping cart on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,6 +435,11 @@
                 flex-direction: column;
                 gap: 10px;
             }
+
+            /* Prevent logo from overlapping the cart button */
+            .header-logo {
+                margin: 120px 0 40px 0;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- prevent cart button overlap by increasing mobile top margin for the logo

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e4e3b7d1483298ba5a21f01bf2f18