### PR TITLE
Remove duplicate thumbnails for single-view shirts

### DIFF
--- a/shirt1.html
+++ b/shirt1.html
@@ -579,9 +579,6 @@
                 <img src="shirt1.png" alt="Shirt 1 Design - Main" class="main-image" id="mainImage">
                 <div class="thumbnail-grid">
                     <img src="shirt1.png" alt="Shirt 1 - Front" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt1.png" alt="Shirt 1 - Back" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt1.png" alt="Shirt 1 - Detail" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt1.png" alt="Shirt 1 - Lifestyle" class="thumbnail" onclick="changeImage(this)">
                 </div>
             </div>
             

--- a/shirt2.html
+++ b/shirt2.html
@@ -578,9 +578,6 @@
                 <img src="shirt2.png" alt="Shirt 2 Design - Main" class="main-image" id="mainImage">
                 <div class="thumbnail-grid">
                     <img src="shirt2.png" alt="Shirt 2 - Front" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt2.png" alt="Shirt 2 - Back" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt2.png" alt="Shirt 2 - Detail" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt2.png" alt="Shirt 2 - Lifestyle" class="thumbnail" onclick="changeImage(this)">
                 </div>
             </div>
             

--- a/shirt3.html
+++ b/shirt3.html
@@ -578,9 +578,6 @@
                 <img src="shirt3.png" alt="Shirt 3 Design - Main" class="main-image" id="mainImage">
                 <div class="thumbnail-grid">
                     <img src="shirt3.png" alt="Shirt 3 - Front" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt3.png" alt="Shirt 3 - Back" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt3.png" alt="Shirt 3 - Detail" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt3.png" alt="Shirt 3 - Lifestyle" class="thumbnail" onclick="changeImage(this)">
                 </div>
             </div>
             

--- a/shirt5.html
+++ b/shirt5.html
@@ -578,9 +578,6 @@
                 <img src="shirt5.png" alt="Shirt 5 Design - Main" class="main-image" id="mainImage">
                 <div class="thumbnail-grid">
                     <img src="shirt5.png" alt="Shirt 5 - Front" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt5.png" alt="Shirt 5 - Back" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt5.png" alt="Shirt 5 - Detail" class="thumbnail" onclick="changeImage(this)">
-                    <img src="shirt5.png" alt="Shirt 5 - Lifestyle" class="thumbnail" onclick="changeImage(this)">
                 </div>
             </div>
             

--- a/shirt6.html
+++ b/shirt6.html
@@ -578,9 +578,6 @@
                 <img src="black-shirt.png" alt="Black Shirt Design - Main" class="main-image" id="mainImage">
                 <div class="thumbnail-grid">
                     <img src="black-shirt.png" alt="Black Shirt - Front" class="thumbnail" onclick="changeImage(this)">
-                    <img src="black-shirt.png" alt="Black Shirt - Back" class="thumbnail" onclick="changeImage(this)">
-                    <img src="black-shirt.png" alt="Black Shirt - Detail" class="thumbnail" onclick="changeImage(this)">
-                    <img src="black-shirt.png" alt="Black Shirt - Lifestyle" class="thumbnail" onclick="changeImage(this)">
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- Display only front image thumbnails on shirts without alternate views

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c10bf77c84832985f82f850b179fb4