### PR TITLE
Refresh cart entries with current product assets

### DIFF
--- a/archive/shop.html
+++ b/archive/shop.html
@@ -554,6 +554,9 @@
 
             if (existingItem) {
                 existingItem.quantity += 1;
+                existingItem.name = product.name;
+                existingItem.price = product.price;
+                existingItem.image = product.image;
             } else {
                 cart.push({
                     id: itemId,

--- a/index.html
+++ b/index.html
@@ -605,6 +605,9 @@
 
             if (existingItem) {
                 existingItem.quantity += 1;
+                existingItem.name = product.name;
+                existingItem.price = product.price;
+                existingItem.image = product.image;
             } else {
                 cart.push({
                     id: itemId,

--- a/shirt2.html
+++ b/shirt2.html
@@ -721,6 +721,10 @@
 
             if (existingItem) {
                 existingItem.quantity += 1;
+                existingItem.name = product.name;
+                existingItem.price = product.price;
+                existingItem.image = product.image;
+                existingItem.size = selectedSize;
             } else {
                 cart.push({
                     id: itemId,

--- a/shirt3.html
+++ b/shirt3.html
@@ -719,6 +719,10 @@
 
             if (existingItem) {
                 existingItem.quantity += 1;
+                existingItem.name = product.name;
+                existingItem.price = product.price;
+                existingItem.image = product.image;
+                existingItem.size = selectedSize;
             } else {
                 cart.push({
                     id: itemId,

--- a/shirt6.html
+++ b/shirt6.html
@@ -719,6 +719,10 @@ function addToCart() {
 
     if (existingItem) {
         existingItem.quantity += 1;
+        existingItem.name = product.name;
+        existingItem.price = product.price;
+        existingItem.image = product.image;
+        existingItem.size = selectedSize;
     } else {
         cart.push({
             id: itemId,


### PR DESCRIPTION
## Summary
- refresh the cart logic so existing entries adopt the latest product name, price, and image assets
- mirror the update on shirt detail pages and the archived shop to keep stored carts consistent

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68faeb00a2bc8329a1ad004101ee412f