### PR TITLE
Update shirt gallery to use new images

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,16 +484,14 @@
 
     <div class="products">
         <a href="shirt2.html">
-            <img src="shirt2.png" alt="Shirt 2 - 2019 ink">
+            <img src="001.png" alt="Shirt 2 - 2019 ink">
             <div class="product-info">
-                <div class="product-name">Shirt 2</div>
                 <div class="product-price">$30.00</div>
             </div>
         </a>
         <a href="shirt3.html">
-            <img src="shirt3.png" alt="Shirt 3 - 2019 ink">
+            <img src="002.png" alt="Shirt 3 - 2019 ink">
             <div class="product-info">
-                <div class="product-name">Shirt 3</div>
                 <div class="product-price">$30.00</div>
             </div>
         </a>
@@ -526,8 +524,8 @@
 
         // Product data
         const products = {
-            'shirt2': { name: 'Shirt 2', price: 30, image: 'shirt2.png' },
-            'shirt3': { name: 'Shirt 3', price: 30, image: 'shirt3.png' }
+            'shirt2': { name: 'Shirt 2', price: 30, image: '001.png' },
+            'shirt3': { name: 'Shirt 3', price: 30, image: '002.png' }
         };
 
         // Initialize cart on page load

--- a/shirt2.html
+++ b/shirt2.html
@@ -575,9 +575,9 @@
     <div class="container">
         <div class="product-grid">
             <div class="product-images">
-                <img src="shirt2.png" alt="Shirt 2 Design - Main" class="main-image" id="mainImage">
+                <img src="001.png" alt="Shirt 2 Design - Main" class="main-image" id="mainImage">
                 <div class="thumbnail-grid">
-                    <img src="shirt2.png" alt="Shirt 2 - Front" class="thumbnail" onclick="changeImage(this)">
+                    <img src="001.png" alt="Shirt 2 - Front" class="thumbnail" onclick="changeImage(this)">
                 </div>
             </div>
             
@@ -639,7 +639,7 @@
         }
 
         // Product data
-        const product = { name: 'Shirt 2', price: 30, image: 'shirt2.png' };
+        const product = { name: 'Shirt 2', price: 30, image: '001.png' };
 
         // Initialize on page load
         document.addEventListener('DOMContentLoaded', function() {

--- a/shirt3.html
+++ b/shirt3.html
@@ -575,9 +575,9 @@
     <div class="container">
         <div class="product-grid">
             <div class="product-images">
-                <img src="shirt3.png" alt="Shirt 3 Design - Main" class="main-image" id="mainImage">
+                <img src="002.png" alt="Shirt 3 Design - Main" class="main-image" id="mainImage">
                 <div class="thumbnail-grid">
-                    <img src="shirt3.png" alt="Shirt 3 - Front" class="thumbnail" onclick="changeImage(this)">
+                    <img src="002.png" alt="Shirt 3 - Front" class="thumbnail" onclick="changeImage(this)">
                 </div>
             </div>
             
@@ -638,7 +638,7 @@
             localStorage.setItem('cart', JSON.stringify(cart));
         }
 
-        const product = { name: 'Shirt 3', price: 30, image: 'shirt3.png' };
+        const product = { name: 'Shirt 3', price: 30, image: '002.png' };
 
         document.addEventListener('DOMContentLoaded', function() {
             cart = loadCart();


### PR DESCRIPTION
## Summary
- update the storefront to use the new 001.png and 002.png assets for shirts 2 and 3
- remove the redundant product name labels under each shirt card
- ensure the individual shirt pages and cart logic reference the updated image filenames

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690c2e5329908329b118a765eb84f03a